### PR TITLE
feat: support access token and keys auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ src/generated/**
 # LangGraph API
 .langgraph_api
 myenv/
+
+# intelligIDEA
+.idea/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/src/indexMerchandiser.ts
+++ b/src/indexMerchandiser.ts
@@ -22,8 +22,7 @@ const GRAPH_MODEL = process.env.GRAPH_MODEL || 'gpt-4o'
 
 // Create a custom annotation that extends MessagesAnnotation to include cartId
 const MerchandiserState = Annotation.Root({
-  ...MessagesAnnotation.spec,
-  grantType: Annotation<'client_credentials'>
+  ...MessagesAnnotation.spec
   // add any additional state you need
 })
 

--- a/src/indexMerchandiser.ts
+++ b/src/indexMerchandiser.ts
@@ -1,44 +1,44 @@
-import { ToolNode } from "@langchain/langgraph/prebuilt";
+import { ToolNode } from '@langchain/langgraph/prebuilt'
 import {
   Annotation,
   END,
   START,
   StateGraph,
   NodeInterrupt,
-  MessagesAnnotation,
-} from "@langchain/langgraph";
+  MessagesAnnotation
+} from '@langchain/langgraph'
 import {
   BaseMessage,
   ToolMessage,
   HumanMessage,
-  type AIMessage,
-} from "@langchain/core/messages";
-import { ChatOpenAI } from "@langchain/openai";
-import { MERCHANDISER_TOOLS_LIST } from "./tools";
-import { z } from "zod";
+  type AIMessage
+} from '@langchain/core/messages'
+import { ChatOpenAI } from '@langchain/openai'
+import { MERCHANDISER_TOOLS_LIST } from './tools'
+import { z } from 'zod'
 
 // Use environment variable with fallback to "gpt-4o"
-const GRAPH_MODEL = process.env.GRAPH_MODEL || "gpt-4o";
+const GRAPH_MODEL = process.env.GRAPH_MODEL || 'gpt-4o'
 
 // Create a custom annotation that extends MessagesAnnotation to include cartId
 const MerchandiserState = Annotation.Root({
   ...MessagesAnnotation.spec,
-  grantType: Annotation<"client_credentials">,
+  grantType: Annotation<'client_credentials'>
   // add any additional state you need
-});
+})
 
 const llm = new ChatOpenAI({
   model: GRAPH_MODEL,
-  temperature: 0,
-});
+  temperature: 0
+})
 
-const toolNode = new ToolNode(MERCHANDISER_TOOLS_LIST);
+const toolNode = new ToolNode(MERCHANDISER_TOOLS_LIST)
 
 const callModel = async (state: typeof MerchandiserState.State) => {
-  const { messages } = state;
+  const { messages } = state
 
   const systemMessage = {
-    role: "system",
+    role: 'system',
     content: `
       You're an expert merchandiser assistant that is leveraging the power of Elastic Path to complete the task.
       Using the tools provided (and only the tools provided), you should break down the task into smaller tasks and complete the task.
@@ -59,48 +59,43 @@ const callModel = async (state: typeof MerchandiserState.State) => {
       
       The grant type is: client_credentials. Use this grant type when interacting with APIs that require a token.
     `.trim()
-  };
+  }
 
-  const llmWithTools = llm.bindTools(MERCHANDISER_TOOLS_LIST);
-  const result = await llmWithTools.invoke([systemMessage, ...messages],
-    {
-      recursionLimit: 5,
-    }
-  );
+  const llmWithTools = llm.bindTools(MERCHANDISER_TOOLS_LIST)
+  const result = await llmWithTools.invoke([systemMessage, ...messages], {
+    recursionLimit: 5
+  })
 
-  // Simply return the result with the current cart ID
-  return { 
-    messages: result, 
-    grantType: "client_credentials" as const 
-  };
-};
+  return {
+    messages: result,
+    grantType: 'client_credentials' as const
+  }
+}
 
 const shouldContinue = (state: typeof MerchandiserState.State) => {
-  const { messages } = state;
+  const { messages } = state
 
-  const lastMessage = messages[messages.length - 1];
+  const lastMessage = messages[messages.length - 1]
   // Cast here since `tool_calls` does not exist on `BaseMessage`
-  const messageCastAI = lastMessage as AIMessage;
+  const messageCastAI = lastMessage as AIMessage
   // if the last message is not an AI message or it does not have any tool calls, we should end.
-  if (messageCastAI._getType() !== "ai" || !messageCastAI.tool_calls?.length) {
-    console.log("END");
-    return END;
+  if (messageCastAI._getType() !== 'ai' || !messageCastAI.tool_calls?.length) {
+    console.log('END')
+    return END
   }
 
   // Tools are provided, so we should continue.
   // LLM knows what to do next.
-  return "tools";
-};
-
+  return 'tools'
+}
 
 const workflow = new StateGraph(MerchandiserState)
-  .addNode("agent", callModel)
-  .addNode("tools", toolNode)
-  .addEdge(START, "agent")
-  .addConditionalEdges("agent", shouldContinue, ["tools", END])
-  .addEdge("tools", "agent")
-  .addEdge("agent", END);
-
+  .addNode('agent', callModel)
+  .addNode('tools', toolNode)
+  .addEdge(START, 'agent')
+  .addConditionalEdges('agent', shouldContinue, ['tools', END])
+  .addEdge('tools', 'agent')
+  .addEdge('agent', END)
 
 // Remove or comment out the previous graph export
-export const graph = workflow.compile();
+export const graph = workflow.compile()

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,50 +1,59 @@
-import { TavilySearchResults } from "@langchain/community/tools/tavily_search";
-import { tool } from "@langchain/core/tools";
-import { z } from "zod";
-import { execGetRequestTool, execPostRequestTool, execPutRequestTool } from "./utils/apiTools";
+import { TavilySearchResults } from '@langchain/community/tools/tavily_search'
+import { tool } from '@langchain/core/tools'
+import { z } from 'zod'
+import {
+  execGetRequestTool,
+  execPostRequestTool,
+  execPutRequestTool
+} from './utils/apiTools'
 // import { searchCatalogTool } from "./shopper/productTools";
 // import { cartTool } from "./shopper/cartTools";
 // import { fileTool } from "./merchandiser/fileTools";
 // import { managePIMTool } from "./merchandiser/pimTools";
-import { cartAPITool, catalogAPITool, catalogAdminAPITool, fileAPITool, pimAPITool, pricebookAPITool } from "./utils/ragTools";
-
-
-export const webSearchTool = tool(
-  async ({ query }) => {
-    console.log(`web_search: ${query}`);
-    const webSearchTool = new TavilySearchResults({
-      maxResults: 2,
-    });
-    const results = await webSearchTool.invoke(query);
-    return JSON.stringify(results);
-  },
-  {
-    name: "web_search",
-    description: "Search the web for the query",
-    schema: z.object({
-      query: z.string().describe("The query to search the web for")
-    })
-  }
-);
-
-
-
-
-// export const SHOPPER_TOOLS_LIST = [ webSearchTool, searchCatalogTool, cartTool];
-export const SHOPPER_TOOLS_LIST = [ 
-  catalogAPITool, 
-  cartAPITool, 
-  execGetRequestTool, 
-  execPostRequestTool
-];
-
-// export const MERCHANDISER_TOOLS_LIST = [ managePIMTool, fileTool];
-export const MERCHANDISER_TOOLS_LIST = [  
+import {
+  cartAPITool,
+  catalogAPITool,
+  catalogAdminAPITool,
   fileAPITool,
   pimAPITool,
   pricebookAPITool,
-  catalogAdminAPITool, 
-  execGetRequestTool, 
-  execPostRequestTool, 
+  subscriptionsAPITool
+} from './utils/ragTools'
+
+export const webSearchTool = tool(
+  async ({ query }) => {
+    console.log(`web_search: ${query}`)
+    const webSearchTool = new TavilySearchResults({
+      maxResults: 2
+    })
+    const results = await webSearchTool.invoke(query)
+    return JSON.stringify(results)
+  },
+  {
+    name: 'web_search',
+    description: 'Search the web for the query',
+    schema: z.object({
+      query: z.string().describe('The query to search the web for')
+    })
+  }
+)
+
+// export const SHOPPER_TOOLS_LIST = [ webSearchTool, searchCatalogTool, cartTool];
+export const SHOPPER_TOOLS_LIST = [
+  catalogAPITool,
+  cartAPITool,
+  execGetRequestTool,
+  execPostRequestTool
+]
+
+// export const MERCHANDISER_TOOLS_LIST = [ managePIMTool, fileTool];
+export const MERCHANDISER_TOOLS_LIST = [
+  fileAPITool,
+  pimAPITool,
+  subscriptionsAPITool,
+  pricebookAPITool,
+  catalogAdminAPITool,
+  execGetRequestTool,
+  execPostRequestTool,
   execPutRequestTool
-];
+]

--- a/src/types/ep-auth.ts
+++ b/src/types/ep-auth.ts
@@ -1,0 +1,14 @@
+export type EpTokenAuthentication = {
+  __access_token: string
+  epStoreId?: string
+  epOrganizationId?: string
+  epBaseUrl?: string
+}
+
+export type EpKeysAuthentication = {
+  grantType: 'client_credentials' | 'implicit'
+  clientId: string
+  clientSecret: string
+}
+
+export type EpAuthentication = EpTokenAuthentication | EpKeysAuthentication

--- a/src/types/merchandiser-runnable.ts
+++ b/src/types/merchandiser-runnable.ts
@@ -1,0 +1,12 @@
+import { BaseCallbackConfig } from '@langchain/core/callbacks/manager'
+import { EpAuthentication } from './ep-auth'
+
+/**
+ * This represents the expected configurable type for the Merchandiser Agent
+ */
+export interface MerchandiserRunnableConfigurable
+  extends BaseCallbackConfig,
+    Record<string, any> {
+  epAuthentication: EpAuthentication
+  epBaseUrl?: string
+}

--- a/src/utils/apiTools.ts
+++ b/src/utils/apiTools.ts
@@ -1,6 +1,13 @@
-import { execPostRequest, execGetRequest, execPutRequest } from "lib/execRequests";
-import { z } from "zod";
-import { tool } from "@langchain/core/tools";
+import {
+  execPostRequest,
+  execGetRequest,
+  execPutRequest
+} from 'lib/execRequests'
+import { z } from 'zod'
+import { tool } from '@langchain/core/tools'
+import { RunnableConfig } from '@langchain/core/runnables'
+import { MerchandiserRunnableConfigurable } from '../types/merchandiser-runnable'
+import { resolveEpRequestParams } from './resolve-ep-request-params'
 
 /**
  * Execute a GET request to the API
@@ -9,22 +16,33 @@ import { tool } from "@langchain/core/tools";
  * @returns The results of the GET request
  */
 export const execGetRequestTool = tool(
-  async ({ endpoint, grantType }) => {
-    console.log(`execGetRequestTool: ${endpoint}`, grantType);
-    const { access_token: token } = await getToken(grantType);
-    console.log(`token: ${token}`);
-    const results = await execGetRequest(endpoint, token);
-    return JSON.stringify(results);
+  async (
+    { endpoint },
+    config: RunnableConfig<MerchandiserRunnableConfigurable>
+  ) => {
+    if (!config?.configurable?.epAuthentication) {
+      throw new Error(`No "epAuthentication" found in configurable`)
+    }
+
+    const options = await resolveEpRequestParams(
+      config.configurable.epAuthentication,
+      config.configurable.epBaseUrl
+    )
+
+    const results = await execGetRequest({
+      endpoint,
+      ...options
+    })
+    return JSON.stringify(results)
   },
   {
-    name: "execGetRequestTool",
-    description: "Execute a GET request to the API",
+    name: 'execGetRequestTool',
+    description: 'Execute a GET request to the API',
     schema: z.object({
-      endpoint: z.string().describe("The API endpoint to call"),
-      grantType: z.enum(["implicit", "client_credentials"]).describe("The type of token to get. Must be either 'implicit' or 'client_credentials'")
+      endpoint: z.string().describe('The API endpoint to call')
     })
   }
-);
+)
 
 /**
  * Execute a POST request to the API
@@ -32,36 +50,41 @@ export const execGetRequestTool = tool(
  * @param body - The body of the POST request
  * @param grantType - The type of token to get. Must be either 'implicit' or 'client_credentials'
  * @returns The results of the POST request
- * @example
- * // Example usage:
- * const result = await execPostRequestTool.invoke({
- *   endpoint: "/carts",
- *   body: { "data": { "type": "cart" } },
- *   grantType: "implicit"
- * });
  */
 export const execPostRequestTool = tool(
-  async ({ endpoint, body = {}, grantType }) => {
-    console.log(`execPostRequestTool: ${endpoint}`, body, grantType);
-    const { access_token: token } = await getToken(grantType);
-    console.log(`token: ${token}`);
-    const results = await execPostRequest(endpoint, token, body);
-    return JSON.stringify(results);
+  async (
+    { endpoint, body },
+    config: RunnableConfig<MerchandiserRunnableConfigurable>
+  ) => {
+    if (!config?.configurable?.epAuthentication) {
+      throw new Error(`No "epAuthentication" found in configurable`)
+    }
+
+    const options = await resolveEpRequestParams(
+      config.configurable.epAuthentication,
+      config.configurable.epBaseUrl
+    )
+
+    const results = await execPostRequest({
+      ...options,
+      endpoint,
+      body
+    })
+    return JSON.stringify(results)
   },
   {
-    name: "execPostRequestTool",
-    description: "Execute a POST request to the API",
+    name: 'execPostRequestTool',
+    description: 'Execute a POST request to the API',
     schema: z.object({
       endpoint: z.string().describe("The API endpoint to call"),
       body: z.record(z.any())
         .describe("The body of the POST request - REQUIRED")
         .refine(body => Object.keys(body).length > 0, {
           message: "POST requests require a non-empty body object"
-        }),
-      grantType: z.enum(["implicit", "client_credentials"]).describe("The type of token to get. Must be either 'implicit' or 'client_credentials'")
+        })
     })
   }
-);
+)
 
 /**
  * Execute a PUT request to the API
@@ -71,50 +94,84 @@ export const execPostRequestTool = tool(
  * @returns The results of the PUT request
  */
 export const execPutRequestTool = tool(
-  async ({ endpoint, body, data, grantType }) => {
-    const payload = body || data;
+  async (
+    { endpoint, body, data },
+    config: RunnableConfig<MerchandiserRunnableConfigurable>
+  ) => {
+    const payload = body || data
     if (!payload) {
-      throw new Error("Either 'body' or 'data' must be provided");
+      throw new Error("Either 'body' or 'data' must be provided")
     }
-    
-    console.log(`execPutRequestTool: ${endpoint}`, payload, grantType);
-    const { access_token: token } = await getToken(grantType);
-    const results = await execPutRequest(endpoint, token, payload);
-    return JSON.stringify(results);
+
+    if (!config?.configurable?.epAuthentication) {
+      throw new Error(`No "epAuthentication" found in configurable`)
+    }
+
+    console.log(`execPutRequestTool: ${endpoint}`, payload)
+
+    const options = await resolveEpRequestParams(
+      config.configurable.epAuthentication,
+      config.configurable.epBaseUrl
+    )
+
+    const results = await execPutRequest({
+      ...options,
+      endpoint,
+      body: payload
+    })
+    return JSON.stringify(results)
   },
   {
-    name: "execPutRequestTool",
-    description: "Execute a PUT request to the API",
+    name: 'execPutRequestTool',
+    description: 'Execute a PUT request to the API',
     schema: z.object({
-      endpoint: z.string().describe("The API endpoint to call"),
-      body: z.record(z.any()).optional().describe("The JSON data to send in the PUT request"),
-      data: z.record(z.any()).optional().describe("Alternative name for the JSON data to send in the PUT request"),
-      grantType: z.enum(["implicit", "client_credentials"]).describe("The type of token to get. Must be either 'implicit' or 'client_credentials'")
+      endpoint: z.string().describe('The API endpoint to call'),
+      body: z
+        .record(z.any())
+        .optional()
+        .describe('The JSON data to send in the PUT request'),
+      data: z
+        .record(z.any())
+        .optional()
+        .describe(
+          'Alternative name for the JSON data to send in the PUT request'
+        )
     })
   }
-);
+)
 
 /**
  * Get a token for the API
  * @param grantType - The type of token to get. Must be either 'implicit' or 'client_credentials'
+ * @param baseUrl - The base URL of the API
  * @returns The token
  */
-export async function getToken(grantType: string): Promise<{ access_token: any; }> {
-  if (grantType !== "implicit" && grantType !== "client_credentials") {
-    throw new Error("Invalid token type. Must be either 'implicit' or 'client_credentials'");
+export async function getToken(
+  grantType: string,
+  baseUrl?: string
+): Promise<{ access_token: any }> {
+  if (grantType !== 'implicit' && grantType !== 'client_credentials') {
+    throw new Error(
+      "Invalid token type. Must be either 'implicit' or 'client_credentials'"
+    )
   }
 
   const body: Record<string, string> = {
-    "grant_type": grantType,
-    "client_id": process.env.EP_CLIENT_ID,
-  };
-
-  if (grantType === "client_credentials") {
-    body["client_secret"] = process.env.EP_CLIENT_SECRET;
+    grant_type: grantType,
+    client_id: process.env.EP_CLIENT_ID
   }
 
-  const result = await execPostRequest("/oauth/access_token", "", body);
+  if (grantType === 'client_credentials') {
+    body['client_secret'] = process.env.EP_CLIENT_SECRET
+  }
 
-  return result.data;
+  const result = await execPostRequest({
+    endpoint: '/oauth/access_token',
+    token: '',
+    body,
+    baseUrl
+  })
+
+
+    return result.data
 }
-

--- a/src/utils/ragTools.ts
+++ b/src/utils/ragTools.ts
@@ -1,15 +1,18 @@
-import { z } from "zod";
-import { tool } from "@langchain/core/tools";
-import { findAPISpecification } from "lib/mongoDBRetriever";
-import { ChatOpenAI } from "@langchain/openai";
+import { z } from 'zod'
+import { tool } from '@langchain/core/tools'
+import { findAPISpecification } from 'lib/mongoDBRetriever'
+import { ChatOpenAI } from '@langchain/openai'
 
-const AGENT_MODEL = process.env.AGENT_MODEL || "gpt-4o-mini";
+const AGENT_MODEL = process.env.AGENT_MODEL || 'gpt-4o-mini'
 
-export async function APITool(query: string, apiName: string, conversationHistory: string[] = []) {
-
+export async function APITool(
+  query: string,
+  apiName: string,
+  conversationHistory: string[] = []
+) {
   // First, plan the action before retrieving API specs
   const planningMessage = {
-    role: "system",
+    role: 'system',
     content: `
       You are an action planner that converts user queries into structured plans.
       Given a user query, break it down into:
@@ -26,28 +29,32 @@ export async function APITool(query: string, apiName: string, conversationHistor
       - Expected outcome: List of matching products with prices and availability
       - Potential API actions: Product search/filter endpoint
     `.trim()
-  };
+  }
 
   const llm = new ChatOpenAI({
     model: AGENT_MODEL,
-    temperature: 0,
-  });
+    temperature: 0
+  })
 
   // Generate action plan
-  const planResult = await llm.invoke([planningMessage, { role: "user", content: query }]);
-  console.log(`Action plan: ${planResult.content}`);
-  
+  const planResult = await llm.invoke([
+    planningMessage,
+    { role: 'user', content: query }
+  ])
+  console.log(`Action plan: ${planResult.content}`)
+
   // Now retrieve relevant API specs with the enriched understanding
-  const specResults = await findAPISpecification(query, apiName);
-  const context = specResults.map(doc => doc.pageContent).join('\n\n');
-  
+  const specResults = await findAPISpecification(query, apiName)
+  const context = specResults.map((doc) => doc.pageContent).join('\n\n')
+
   // Include conversation history for context if available
-  const historyContext = conversationHistory.length > 0 
-    ? `Previous conversation context:\n${conversationHistory.join('\n')}\n\n` 
-    : '';
-  
+  const historyContext =
+    conversationHistory.length > 0
+      ? `Previous conversation context:\n${conversationHistory.join('\n')}\n\n`
+      : ''
+
   const systemMessage = {
-    role: "system",
+    role: 'system',
     content: `
       You are an API execution planner that converts user intents into precise API calls.
       
@@ -64,16 +71,16 @@ export async function APITool(query: string, apiName: string, conversationHistor
       
       Be precise and focus on translating user intent into a valid API action.
     `.trim()
-  };
-  
-  systemMessage.content += `\n\n${historyContext}User query: ${query}\n\nAction plan: ${planResult.content}\n\nAvailable OpenAPI specs:\n${context}`;
+  }
+
+  systemMessage.content += `\n\n${historyContext}User query: ${query}\n\nAction plan: ${planResult.content}\n\nAvailable OpenAPI specs:\n${context}`
 
   // Generate final API execution plan
-  const result = await llm.invoke([systemMessage]);
-  
+  const result = await llm.invoke([systemMessage])
+
   // Validate the generated action against the original intent
   const validationMessage = {
-    role: "system",
+    role: 'system',
     content: `
       Validate if the following API execution plan correctly addresses the user's query.
       
@@ -85,16 +92,16 @@ export async function APITool(query: string, apiName: string, conversationHistor
       "VALID" if the execution plan correctly addresses the user's query, or
       "NEEDS_REVISION: [specific reason]" if the plan doesn't properly address the query.
     `.trim()
-  };
-  
-  const validationResult = await llm.invoke([validationMessage]);
-  const validationResponse = validationResult.content.toString();
-  
-  if (validationResponse.includes("NEEDS_REVISION")) {
-    console.log(`Validation failed: ${validationResponse}`);
+  }
+
+  const validationResult = await llm.invoke([validationMessage])
+  const validationResponse = validationResult.content.toString()
+
+  if (validationResponse.includes('NEEDS_REVISION')) {
+    console.log(`Validation failed: ${validationResponse}`)
     // Try one more time with the feedback
     const revisedSystemMessage = {
-      role: "system",
+      role: 'system',
       content: `
         Revise the API execution plan based on this feedback: ${validationResponse}
         
@@ -102,119 +109,157 @@ export async function APITool(query: string, apiName: string, conversationHistor
         Previous plan: ${result.content}
         Available OpenAPI specs:\n${context}
       `.trim()
-    };
-    
-    const revisedResult = await llm.invoke([revisedSystemMessage]);
-    console.log(`Revised APITool result: ${revisedResult.content}`);
-    return revisedResult.content;
-  }
-  
-  console.log(`APITool result: ${result.content}`);
-  return result.content;
-};
+    }
 
+    const revisedResult = await llm.invoke([revisedSystemMessage])
+    console.log(`Revised APITool result: ${revisedResult.content}`)
+    return revisedResult.content
+  }
+
+  console.log(`APITool result: ${result.content}`)
+  return result.content
+}
 
 export const cartAPITool = tool(
   async ({ query }: { query: string }, conversationHistory: string[] = []) => {
-    return await APITool(query, "carts", conversationHistory);
+    return await APITool(query, 'carts', conversationHistory)
   },
   {
-    name: "cartAPITool",
-    description: "Information about the cart API, add a product to the cart, or update a product from the cart, or checkout the cart ",
+    name: 'cartAPITool',
+    description:
+      'Information about the cart API, add a product to the cart, or update a product from the cart, or checkout the cart ',
     schema: z.object({
-      query: z.string().describe("The user query to match the API specification"),
+      query: z
+        .string()
+        .describe('The user query to match the API specification')
     })
   }
-);
+)
 
 export const catalogAPITool = tool(
   async ({ query }: { query: string }, conversationHistory: string[] = []) => {
-    return await APITool(query, "catalog", conversationHistory);
+    return await APITool(query, 'catalog', conversationHistory)
   },
   {
-    name: "catalogAPITool",
-    description: "Information about the catalog API, add a product to the catalog, or update a product from the catalog, or checkout the catalog ",
+    name: 'catalogAPITool',
+    description:
+      'Information about the catalog API, add a product to the catalog, or update a product from the catalog, or checkout the catalog ',
     schema: z.object({
-      query: z.string().describe("The user query to match the API specification"),
+      query: z
+        .string()
+        .describe('The user query to match the API specification')
     })
   }
-);
+)
 
 export const catalogAdminAPITool = tool(
   async ({ query }: { query: string }, conversationHistory: string[] = []) => {
-    return await APITool(query, "catalog-admin", conversationHistory);
+    return await APITool(query, 'catalog-admin', conversationHistory)
   },
   {
-    name: "catalogAdminAPITool",
-    description: "Information about the catalog admin API, create a catalog, publish a catalog, retrieves different catalogs, manage catalog attributes, ",
+    name: 'catalogAdminAPITool',
+    description:
+      'Information about the catalog admin API, create a catalog, publish a catalog, retrieves different catalogs, manage catalog attributes, ',
     schema: z.object({
-      query: z.string().describe("The user query to match the API specification"),
+      query: z
+        .string()
+        .describe('The user query to match the API specification')
     })
   }
-);
+)
 
 export const pimAPITool = tool(
   async ({ query }: { query: string }, conversationHistory: string[] = []) => {
-    return await APITool(query, "pim", conversationHistory);
+    return await APITool(query, 'pim', conversationHistory)
   },
   {
-    name: "pimAPITool",
-    description: "Manage the products, variations, bundles, hierarchies, nodes in Product Experience Manager (PXM) ",
+    name: 'pimAPITool',
+    description:
+      'Manage the products, variations, bundles, hierarchies, nodes in Product Experience Manager (PXM) ',
     schema: z.object({
-      query: z.string().describe("The user query to match the API specification"),
+      query: z
+        .string()
+        .describe('The user query to match the API specification')
     })
   }
-);
+)
+
+export const subscriptionsAPITool = tool(
+  async ({ query }: { query: string }, conversationHistory: string[] = []) => {
+    return await APITool(query, 'subscriptions', conversationHistory)
+  },
+  {
+    name: 'subscriptionsAPITool',
+    description:
+      'Information about the subscriptions API, manage an offering, products, plans and features. Subscriptions are used to manage recurring orders for your customers.  ',
+    schema: z.object({
+      query: z
+        .string()
+        .describe('The user query to match the API specification')
+    })
+  }
+)
 
 export const fileAPITool = tool(
   async ({ query }: { query: string }, conversationHistory: string[] = []) => {
-    return await APITool(query, "files", conversationHistory);
+    return await APITool(query, 'files', conversationHistory)
   },
   {
-    name: "fileAPITool",
-    description: "Information about the file API, upload a file, download a file, delete a file, ",
+    name: 'fileAPITool',
+    description:
+      'Information about the file API, upload a file, download a file, delete a file, ',
     schema: z.object({
-      query: z.string().describe("The user query to match the API specification"),
+      query: z
+        .string()
+        .describe('The user query to match the API specification')
     })
   }
-);
+)
 
 export const pricebookAPITool = tool(
   async ({ query }: { query: string }, conversationHistory: string[] = []) => {
-    return await APITool(query, "pricebooks", conversationHistory);
+    return await APITool(query, 'pricebooks', conversationHistory)
   },
   {
-    name: "pricebookAPITool",
-    description: "Information about the pricebook API, create a pricebook, update a pricebook, retrieve a pricebook, delete a pricebook. Pricebooks contain prices for the products in your catalog.  ",
+    name: 'pricebookAPITool',
+    description:
+      'Information about the pricebook API, create a pricebook, update a pricebook, retrieve a pricebook, delete a pricebook. Pricebooks contain prices for the products in your catalog.  ',
     schema: z.object({
-      query: z.string().describe("The user query to match the API specification"),
+      query: z
+        .string()
+        .describe('The user query to match the API specification')
     })
   }
-);
+)
 
 export const promotionAPITool = tool(
   async ({ query }: { query: string }, conversationHistory: string[] = []) => {
-    return await APITool(query, "promotions-builder", conversationHistory);
+    return await APITool(query, 'promotions-builder', conversationHistory)
   },
   {
-    name: "promotionAPITool",
-    description: "Information about the promotion API, create a promotion, update a promotion, retrieve a promotion, delete a promotion. Promotions are used to apply discounts to products in your catalog.  ",
+    name: 'promotionAPITool',
+    description:
+      'Information about the promotion API, create a promotion, update a promotion, retrieve a promotion, delete a promotion. Promotions are used to apply discounts to products in your catalog.  ',
     schema: z.object({
-      query: z.string().describe("The user query to match the API specification"),
+      query: z
+        .string()
+        .describe('The user query to match the API specification')
     })
   }
-);
+)
 
 export const accountAPITool = tool(
   async ({ query }: { query: string }, conversationHistory: string[] = []) => {
-    return await APITool(query, "accounts", conversationHistory);
+    return await APITool(query, 'accounts', conversationHistory)
   },
   {
-    name: "accountAPITool",
-    description: "Information about the account API, create an account, update an account, retrieve an account, delete an account. Accounts are used to manage your customers.  ",
+    name: 'accountAPITool',
+    description:
+      'Information about the account API, create an account, update an account, retrieve an account, delete an account. Accounts are used to manage your customers.  ',
     schema: z.object({
-      query: z.string().describe("The user query to match the API specification"),
+      query: z
+        .string()
+        .describe('The user query to match the API specification')
     })
   }
-);
-
+)

--- a/src/utils/resolve-ep-request-params.ts
+++ b/src/utils/resolve-ep-request-params.ts
@@ -1,0 +1,30 @@
+import { EpAuthentication } from '../types/ep-auth'
+import { getToken } from './apiTools'
+
+export async function resolveEpRequestParams(
+  epAuthentication: EpAuthentication,
+  baseUrl?: string
+): Promise<{
+  token: string
+  customHeaders?: Record<string, string>
+  baseUrl: string
+}> {
+  if ('__access_token' in epAuthentication) {
+    const { epStoreId, epOrganizationId, epBaseUrl, __access_token } =
+      epAuthentication
+    return {
+      token: epAuthentication.__access_token,
+      baseUrl,
+      customHeaders: {
+        ...(epStoreId && { 'Ep-Store-Id': epStoreId }),
+        ...(epOrganizationId && { 'Ep-Org-Id': epOrganizationId })
+      }
+    }
+  } else {
+    const { grantType, clientId, clientSecret } = epAuthentication
+    return {
+      token: (await getToken(grantType, baseUrl)).access_token,
+      baseUrl
+    }
+  }
+}


### PR DESCRIPTION
# Elastic Path auth configuration

Supports two methods for the agent to authenticate with Elastic Path. It can use either a key based approach with client id and secret or and access token based approach.

## Key Approach
```
stream.submit(
      {
        messages: ...
      },
      {
        ...
        config: {
          configurable: {
            epAuthentication: {
              grantType: 'client_credentials',
              clientId:
                'AZekPwbxPXHYO3tCNM63F4hKXEj2eZOQoqL86UXnrW #7ZZMeYabxyPgddhik9gMt6yCvAAzs15lAuRjC8PbRw',
              clientSecret: ''
            },
            epBaseUrl: 'https://useast.api.elasticpath.com'
          }
        }
      }
    )
```

## Access token Approach

The property `__access_token` has a double underscore to avoid being logged with langgraph any properties in the configuration with dunders are considered "secrets" 

```
stream.submit(
      {
        messages: ...
      },
      {
        ...
        config: {
          configurable: {
            epAuthentication: {
              epStoreId: "abc",
              epOrganizationId: "abc",
              __access_token: "my-token"
            },
            epBaseUrl: 'https://useast.api.elasticpath.com'
          }
        }
      }
    )
```